### PR TITLE
Add time format match

### DIFF
--- a/matcher.go
+++ b/matcher.go
@@ -5,7 +5,71 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 )
+
+const (
+	weekdaysAbv   = "((Mon)|(Tue)|(Wed)|(Thu)|(Fri)|(Sat)|(Sun))"
+	weekdays      = "((Monday)|(Tuesday)|(Wednesday)|(Thursday)|(Friday)|(Saturday)|(Sunday))"
+	monthsAbv     = "((Jan)|(Feb)|(Mar)|(Apr)|(May)|(Jun)|(Jul)|(Aug)|(Sep)|(Oct)|(Nov)|(Dec))"
+	numericmonths = "(0[1-9]|1[0-2])"
+	days          = "((_[1-9])|([1-2][0-9])|3[01])"               // _1 - 31
+	daysWithZero  = "((0[1-9])|([1-2][0-9])|3[01])"               // 01 - 31
+	hhmmss        = "(([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9])" // 22:15:02
+	hhmm          = "(([0-1][0-9]|2[0-3]):[0-5][0-9])"            // 22:15
+	year          = "[0-9]{4}"                                    // 2006
+	timezone      = "[A-Z]{3}"                                    // MST
+	numericZone   = "-[0-9]{4}"                                   // -0300
+	milli         = ".[0-9]{3}"
+	micro         = ".[0-9]{6}"
+	nano          = ".[0-9]{9}"
+)
+
+var (
+	ANSICRegex 		 = regexp.MustCompile(fmt.Sprintf("%s %s %s %s %s", weekdaysAbv, monthsAbv, days, hhmmss,
+		year))
+	UnixDateRegex 	 = regexp.MustCompile(fmt.Sprintf("%s %s %s %s %s %s", weekdaysAbv, monthsAbv, days, hhmmss,
+		timezone, year))
+	RubyDateRegex 	 = regexp.MustCompile(fmt.Sprintf("%s %s %s %s %s %s", weekdaysAbv, monthsAbv, daysWithZero,
+		hhmmss, numericZone, year))
+	RFC822Regex 	 = regexp.MustCompile(fmt.Sprintf("%s %s [0-9]{2} %s %s", daysWithZero, monthsAbv, hhmm,
+		timezone))
+	RFC822ZRegex 	 = regexp.MustCompile(fmt.Sprintf("%s %s [0-9]{2} %s %s", daysWithZero, monthsAbv, hhmm,
+		numericZone))
+	RFC850Regex 	 = regexp.MustCompile(fmt.Sprintf("%s, %s-%s-[0-9]{2} %s %s", weekdays, daysWithZero,
+		monthsAbv, hhmmss, timezone))
+	RFC1123Regex 	 = regexp.MustCompile(fmt.Sprintf("%s, %s %s %s %s %s", weekdaysAbv, daysWithZero, monthsAbv,
+		year, hhmmss, timezone))
+	RFC1123ZRegex 	 = regexp.MustCompile(fmt.Sprintf("%s, %s %s %s %s %s", weekdaysAbv, daysWithZero, monthsAbv,
+		year, hhmmss, numericZone))
+	RFC3339Regex 	 = regexp.MustCompile(fmt.Sprintf("%s-%s-%sT%sZ%s", year, numericmonths, daysWithZero,
+		hhmmss, hhmm))
+	RFC3339NanoRegex = regexp.MustCompile(fmt.Sprintf("%s-%s-%sT%s%sZ%s", year, numericmonths, daysWithZero,
+		hhmmss, nano, hhmm))
+	KitchenRegex 	 = regexp.MustCompile("(([0-1]?[0-9]|2[0-3]):[0-5][0-9][P|A]M)")
+	StampRegex 		 = regexp.MustCompile(fmt.Sprintf("%s %s %s", monthsAbv, days, hhmmss))
+	StampMilliRegex  = regexp.MustCompile(fmt.Sprintf("%s %s %s%s", monthsAbv, days, hhmmss, milli))
+	StampMicroRegex  = regexp.MustCompile(fmt.Sprintf("%s %s %s%s", monthsAbv, days, hhmmss, micro))
+	StampNanoRegex   = regexp.MustCompile(fmt.Sprintf("%s %s %s%s", monthsAbv, days, hhmmss, nano))
+)
+
+var layoutRegexps = map[string]*regexp.Regexp{
+	time.ANSIC: 	  ANSICRegex,
+	time.UnixDate: 	  UnixDateRegex,
+	time.RubyDate: 	  RubyDateRegex,
+	time.RFC822: 	  RFC822Regex,
+	time.RFC822Z: 	  RFC822ZRegex,
+	time.RFC850: 	  RFC850Regex,
+	time.RFC1123: 	  RFC1123Regex,
+	time.RFC1123Z: 	  RFC1123ZRegex,
+	time.RFC3339: 	  RFC3339Regex,
+	time.RFC3339Nano: RFC3339NanoRegex,
+	time.Kitchen: 	  KitchenRegex,
+	time.Stamp: 	  StampRegex,
+	time.StampMilli:  StampMilliRegex,
+	time.StampMicro:  StampMicroRegex,
+	time.StampNano:   StampNanoRegex,
+}
 
 type MatcherFunc func(string) Match
 
@@ -44,6 +108,15 @@ func MatchRegexp(r *regexp.Regexp) MatcherFunc {
 			Template: r.ReplaceAllString(str, "%s"),
 			Patterns: r.FindAllString(str, -1),
 		}
+	}
+}
+
+// MatchTimestamp returns a MatcherFunc that matches a time layout pattern in given string
+func MatchTimestamp(layout string) MatcherFunc{
+	return func(str string) Match {
+		r := layoutRegexps[layout]
+
+		return MatchRegexp(r)(str)
 	}
 }
 

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -3,6 +3,7 @@ package marker
 import (
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -37,6 +38,190 @@ func Test_MatchRegexp(t *testing.T) {
 	expectedMatch := Match{Template: "I %s, you all %s, we all %s for ice %s.", Patterns: []string{"scream", "scream", "scream", "cream"}}
 
 	assert.Equal(t, expectedMatch, actualMatch)
+}
+
+func Test_MatchTimestamp(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ANSIC", func(t *testing.T) {
+		str := "Current timestamp is Mon Jan 31 20:59:00 2006"
+		match := MatchTimestamp(time.ANSIC)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"Mon Jan 31 20:59:00 2006"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("UnixDate", func(t *testing.T) {
+		str := "Current timestamp is Mon Jan _2 03:04:05 MST 2006"
+		match := MatchTimestamp(time.UnixDate)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"Mon Jan _2 03:04:05 MST 2006"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("RubyDate", func(t *testing.T) {
+		str := "Current timestamp is Fri Feb 04 03:04:05 -0300 2006"
+		match := MatchTimestamp(time.RubyDate)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"Fri Feb 04 03:04:05 -0300 2006"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("RFC822", func(t *testing.T) {
+		str := "Current timestamp is 02 Jan 06 05:04 MST"
+		match := MatchTimestamp(time.RFC822)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"02 Jan 06 05:04 MST"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("RFC822Z", func(t *testing.T) {
+		str := "Current timestamp is 02 Jan 06 15:04 -0300"
+		match := MatchTimestamp(time.RFC822Z)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"02 Jan 06 15:04 -0300"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("RFC850", func(t *testing.T) {
+		str := "Current timestamp is Saturday, 07-Aug-06 22:04:59 MST"
+		match := MatchTimestamp(time.RFC850)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"Saturday, 07-Aug-06 22:04:59 MST"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("RFC1123", func(t *testing.T) {
+		str := "Current timestamp is Mon, 02 Jan 2006 15:04:05 MST"
+		match := MatchTimestamp(time.RFC1123)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"Mon, 02 Jan 2006 15:04:05 MST"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("RFC1123Z", func(t *testing.T) {
+		str := "Current timestamp is Mon, 02 Jan 2006 15:04:05 -0300"
+		match := MatchTimestamp(time.RFC1123Z)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"Mon, 02 Jan 2006 15:04:05 -0300"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("RFC3339", func(t *testing.T) {
+		str := "Current timestamp is 2006-01-02T15:04:05Z07:00"
+		match := MatchTimestamp(time.RFC3339)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"2006-01-02T15:04:05Z07:00"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("RFC3339Nano", func(t *testing.T) {
+		str := "Current timestamp is 2006-01-02T15:04:05.999999999Z07:00"
+		match := MatchTimestamp(time.RFC3339Nano)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"2006-01-02T15:04:05.999999999Z07:00"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("Kitchen", func(t *testing.T) {
+		str := "Current timestamp is 2:15PM"
+		match := MatchTimestamp(time.Kitchen)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"2:15PM"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("Stamp", func(t *testing.T) {
+		str := "Current timestamp is Jan _2 15:04:05"
+		match := MatchTimestamp(time.Stamp)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"Jan _2 15:04:05"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("StampMilli", func(t *testing.T) {
+		str := "Current timestamp is Jan _2 15:04:05.999"
+		match := MatchTimestamp(time.StampMilli)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"Jan _2 15:04:05.999"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("StampMicro", func(t *testing.T) {
+		str := "Current timestamp is Jan _2 15:04:05.999999"
+		match := MatchTimestamp(time.StampMicro)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"Jan _2 15:04:05.999999"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
+
+	t.Run("StampNano", func(t *testing.T) {
+		str := "Current timestamp is Jan _2 15:04:05.000000000"
+		match := MatchTimestamp(time.StampNano)(str)
+
+		expectedMatch := Match{
+			Template: "Current timestamp is %s",
+			Patterns: []string{"Jan _2 15:04:05.000000000"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+	})
 }
 
 func Test_MatchSurrounded(t *testing.T) {


### PR DESCRIPTION
The day and time regular expressions verify is those are valid (e.g. days regex only recognize 01 to 31, and time regex only recognize 00:00:00 to 23:59:59).

But no verification is being made on the date (e.g. Feb 31 will be recognized).

Closes #8 