### PR TITLE
Fix stamp overlap - MatchTimestamp

### DIFF
--- a/matcher_test.go
+++ b/matcher_test.go
@@ -176,12 +176,22 @@ func Test_MatchTimestamp(t *testing.T) {
 	})
 
 	t.Run("Stamp", func(t *testing.T) {
-		str := "Current timestamp is Jan _2 15:04:05"
+		str := "Current timestamp is Jan _2 15:04:05 and Jan _2 15:04:10"
 		match := MatchTimestamp(time.Stamp)(str)
 
 		expectedMatch := Match{
-			Template: "Current timestamp is %s",
-			Patterns: []string{"Jan _2 15:04:05"},
+			Template: "Current timestamp is %sand %s",
+			Patterns: []string{"Jan _2 15:04:05 ", "Jan _2 15:04:10"},
+		}
+
+		assert.Equal(t, expectedMatch, match)
+
+		str = "Stamps Jan _2 15:04:05.999 and Jan _2 15:04:05.999999 and Jan _2 15:04:05.999999999"
+		match = MatchTimestamp(time.Stamp)(str)
+
+		expectedMatch = Match{
+			Template: "Stamps Jan _2 15:04:05.999 and Jan _2 15:04:05.999999 and Jan _2 15:04:05.999999999",
+			Patterns: nil,
 		}
 
 		assert.Equal(t, expectedMatch, match)

--- a/regexp.go
+++ b/regexp.go
@@ -35,7 +35,7 @@ var (
 	RFC3339Regexp     = regexp.MustCompile(fmt.Sprintf("%s-%s-%sT%sZ%s", year, numericmonths, daysWithZero, hhmmss, hhmm))
 	RFC3339NanoRegexp = regexp.MustCompile(fmt.Sprintf("%s-%s-%sT%s%sZ%s", year, numericmonths, daysWithZero, hhmmss, nano, hhmm))
 	KitchenRegexp     = regexp.MustCompile("(([0-1]?[0-9]|2[0-3]):[0-5][0-9][P|A]M)")
-	StampRegexp       = regexp.MustCompile(fmt.Sprintf("%s %s %s", monthsAbv, days, hhmmss))
+	StampRegexp       = regexp.MustCompile(fmt.Sprintf("%s %s %s(\\s|$)", monthsAbv, days, hhmmss))
 	StampMilliRegexp  = regexp.MustCompile(fmt.Sprintf("%s %s %s%s", monthsAbv, days, hhmmss, milli))
 	StampMicroRegexp  = regexp.MustCompile(fmt.Sprintf("%s %s %s%s", monthsAbv, days, hhmmss, micro))
 	StampNanoRegexp   = regexp.MustCompile(fmt.Sprintf("%s %s %s%s", monthsAbv, days, hhmmss, nano))


### PR DESCRIPTION
Golang's ```regexp``` package, build under google's RE2 engine, doesn't support backtracking and look around assertions (https://github.com/golang/go/issues/18868). Since negative lookahead is the most straight forward solution, I've found this: https://github.com/dlclark/regexp2.

The only downside of using ```regexp2``` (other than adding one more dependency to the project) is that it doesn't have constant time guarantees like the built-in ```regexp``` package, but since it's only used to Timestamp matches, I don't see it being a problem.

https://godoc.org/github.com/dlclark/regexp2
Ref #8 